### PR TITLE
Optional Trip Dispatcher params

### DIFF
--- a/lib/trip_dispatcher.rb
+++ b/lib/trip_dispatcher.rb
@@ -9,10 +9,10 @@ module RideShare
   class TripDispatcher
     attr_reader :drivers, :passengers, :trips
 
-    def initialize
-      @drivers = load_drivers
-      @passengers = load_passengers
-      @trips = load_trips
+    def initialize(drivers=nil, passengers=nil)
+      @drivers = drivers != nil ? drivers : load_drivers
+      @passengers = passengers != nil ? passengers : load_passengers
+      @trips = (drivers != nil || passengers != nil) ? [] : load_trips
     end
 
     def load_drivers

--- a/specs/trip_dispatch_spec.rb
+++ b/specs/trip_dispatch_spec.rb
@@ -89,4 +89,41 @@ describe "TripDispatcher class" do
       passenger.trips.must_include trip
     end
   end
+
+  describe "optional parameters in initialize" do
+    it "optionally takes in drivers parameter, which should make trips array empty" do
+      test_driver = RideShare::Driver.new({id: 1, name: 'Virginia Bartell', vin: '12345678901234567'})
+
+      dispatcher = RideShare::TripDispatcher.new( [ test_driver ] )
+
+      dispatcher.drivers.must_be_kind_of Array
+      dispatcher.drivers.length.must_equal 1
+
+      driver = dispatcher.drivers.first
+      driver.must_be_kind_of RideShare::Driver
+      driver.id.must_equal 1
+      driver.name.must_equal 'Virginia Bartell'
+      driver.vehicle_id.must_equal '12345678901234567'
+
+      dispatcher.passengers.length.must_equal 300
+      dispatcher.trips.must_be_empty
+    end
+
+    it "optionally takes in passengers parameter, which should make trips array empty" do
+      test_passenger = RideShare::Passenger.new({id: 99, name: 'Kali Skiles PhD'})
+
+      dispatcher = RideShare::TripDispatcher.new( nil, [ test_passenger ] )
+
+      dispatcher.passengers.must_be_kind_of Array
+      dispatcher.passengers.length.must_equal 1
+
+      passenger = dispatcher.passengers.first
+      passenger.must_be_kind_of RideShare::Passenger
+      passenger.id.must_equal 99
+      passenger.name.must_equal 'Kali Skiles PhD'
+
+      dispatcher.drivers.length.must_equal 100
+      dispatcher.trips.must_be_empty
+    end
+  end
 end


### PR DESCRIPTION
It'll start to be painful to unit test Wave 3. The student needs to unit test the following things:

- Have a set of Drivers who are available and unavailable,
- of the available drivers, have some who have more than one trip associated with them
  - of these trips, know which trip is most recent
    - of those trips, know which trip is oldest, and pick the driver associated with them

Unless we find that driver in the driver CSV, it'll be pretty goofy for them to work with those tests.

This is a proposal for optional params. With optional params, in tests the students could pass in their own arrays of test drivers and test passengers, which makes the test an isolated way to give their own data.

The thing to decide is:

with these changes: we shouldn't load trips from the CSV if drivers or passengers was passed in, and make the trips array empty in that case.

However, the requirements for assigning drivers tells the students to only consider the trips for each driver who have any trips at all (it assumes each driver has at least one trip).

Of course, in a test, you can just make a test trip and give it to the test drivers, etc, but that requires making Trip Dispatcher having the other parts of "creating a trip" set correctly... which we aren't providing.


for example, the ideal test would be:
```ruby
it "should create a trip that picks the right driver" do
  right_driver = RideShare::Driver.new( ... )
  wrong_driver = RideShare::Driver.new( ... )
  passenger = RideShare::Passenger.new( ... )

  dispatcher = RideShare::Dispatcher.new( [ right_driver, wrong_driver ], [ passenger ] )

  new_trip = dispatcher.create_trip_for_passenger( passenger.id )

  new_trip.driver.must_be right_driver
end
```

But as is, we'd have to do this:
```ruby
it "should create a trip that picks the right driver" do
  right_driver = RideShare::Driver.new( ... )
  wrong_driver = RideShare::Driver.new( ... )
  trip_a = RideShare::Trip.new( ... )
  trip_b = RideShare::Trip.new( ... )
  trip_c = RideShare::Trip.new( ... )
  trip_d = RideShare::Trip.new( ... )
  right_driver.add_trip(trip_a)
  right_driver.add_trip(trip_b)
  wrong_driver.add_trip(trip_c)
  wrong_driver.add_trip(trip_d)

  passenger = RideShare::Passenger.new( ... )
  # optional but...
  passenger.add_trip(trip_a)
  passenger.add_trip(trip_b)
  passenger.add_trip(trip_c)
  passenger.add_trip(trip_d)
  

  dispatcher = RideShare::Dispatcher.new( [ right_driver, wrong_driver ], [ passenger ] )
  dispatcher.trips << trip_a # ... etc

  new_trip = dispatcher.create_trip_for_passenger( passenger.id )

  new_trip.driver.must_be right_driver
end
```

That's where I'm worried and stuck! OK THANKS